### PR TITLE
Updated run-precheck.js validateVersion to work with Meteor 1.3

### DIFF
--- a/lib/run-precheck.js
+++ b/lib/run-precheck.js
@@ -45,6 +45,14 @@ var validateVersion = function(name, cmd, versions) {
             logger.silly(cmd + ' -> stdout: ' + result);
             var matches = result.match(/(\d+\.\d+\.\d+)/g);
             var curr = matches ? matches[0] : null;
+
+            // Meteor 1.3 returns "Meteor 1.3" without a PATCH revision. This isn't semver compliant, so we need
+            // to cater for MAJOR.MINOR. If found, append .0 to make it MAJOR.MINOR.PATCH so that semver works.
+            if (matches == null) {
+                matches = result.match(/(\d+\.\d+)/g);
+                curr = matches ? matches[0] + '.0' : null;
+            }
+
             if(curr && semver.satisfies(curr, versions)){
                 logger.verbose('run-precheck', name + ' has a valid version. Current version: ' + curr + ' Valid version(s): ' + versions);
                 resolve();


### PR DESCRIPTION
This ensures that Meteor 1.3 validates correctly as "meteor --version" doesn't follow semver specifications and only returns MAJOR.MINOR (1.3) instead of MAJOR.MINOR.PATCH (1.3.0).
